### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "wampire"
 version = "0.1.2"
+edition = "2018"
 authors = ["Dudochkin Victor <dudochkin.victor@gmail.com>", "Daniel Yule <yule@cs.dal.ca>"]
 license = "MIT"
 readme = "README.md"
@@ -16,9 +17,8 @@ name = "wampire"
 path = "src/lib.rs"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 url = "1.7"
 log = "0.4"
 env_logger = "0.5"
@@ -31,5 +31,5 @@ itertools = "0.7"
 argparse = "0.2.1"
 
 [features]
-default-features = []
+default = []
 ssl = ["ws/ssl"]

--- a/examples/api_user.rs
+++ b/examples/api_user.rs
@@ -1,13 +1,11 @@
-extern crate eventual;
-extern crate wampire;
-use eventual::Async;
 use std::io;
+
+use log::info;
+use env_logger;
+use eventual::Async;
+
 use wampire::client::{Client, Connection};
 use wampire::{ArgList, Value, URI};
-
-#[macro_use]
-extern crate log;
-extern crate env_logger;
 
 enum Command {
     Add,
@@ -52,6 +50,7 @@ fn process_input(input: &str) -> (Command, Vec<String>) {
     (command, args)
 }
 
+#[allow(clippy::comparison_chain)]
 fn add(client: &mut Client, args: &[String]) {
     if args.len() > 2 {
         println!("Too many arguments to add.  Ignoring");
@@ -81,7 +80,7 @@ fn add(client: &mut Client, args: &[String]) {
             None,
         )
         .unwrap()
-        .await()
+        .r#await()
     {
         Ok((args, _)) => {
             println!("Result: {}", args.get_int(0).unwrap().unwrap());
@@ -98,11 +97,11 @@ fn add(client: &mut Client, args: &[String]) {
 }
 
 fn echo(client: &mut Client, args: Vec<String>) {
-    let args = args.into_iter().map(|arg| Value::String(arg)).collect();
+    let args = args.into_iter().map(Value::String).collect();
     let result = client
         .call(URI::new("ca.test.echo"), Some(args), None)
         .unwrap()
-        .await();
+        .r#await();
     println!("Result: {:?}", result);
 }
 
@@ -131,12 +130,12 @@ fn event_loop(mut client: Client) {
             Command::Invalid(bad_command) => print!("Invalid command: {}", bad_command),
         }
     }
-    client.shutdown().unwrap().await().unwrap();
+    client.shutdown().unwrap().r#await().unwrap();
 }
 
 fn main() {
     env_logger::init();
-    let connection = Connection::new("ws://127.0.0.1:8090/ws", "wampire_realm");
+    let connection = Connection::new("ws://127.0.0.1:8080/ws", "demo");
     info!("Connecting");
     let client = connection.connect().unwrap();
 

--- a/examples/endpoint.rs
+++ b/examples/endpoint.rs
@@ -1,29 +1,24 @@
-extern crate eventual;
-extern crate wampire;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
+use log::info;
+use env_logger;
 
 use eventual::Async;
 use std::io;
 use wampire::client::Connection;
 use wampire::{ArgList, CallResult, Dict, List, Value, URI};
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn addition_callback(args: List, _kwargs: Dict) -> CallResult<(Option<List>, Option<Dict>)> {
     info!("Performing addition");
-    try!(args.verify_len(2));
-    let a = try!(args.get_int(0)).unwrap();
-    let b = try!(args.get_int(1)).unwrap();
+    args.verify_len(2)?;
+    let a = args.get_int(0)?.unwrap();
+    let b = args.get_int(1)?.unwrap();
     Ok((Some(vec![Value::Integer(a + b)]), None))
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn multiplication_callback(args: List, _kwargs: Dict) -> CallResult<(Option<List>, Option<Dict>)> {
     info!("Performing multiplication");
-    try!(args.verify_len(2));
-    let a = try!(args.get_int(0)).unwrap();
-    let b = try!(args.get_int(1)).unwrap();
+    args.verify_len(2)?;
+    let a = args.get_int(0)?.unwrap();
+    let b = args.get_int(1)?.unwrap();
     Ok((Some(vec![Value::Integer(a * b)]), None))
 }
 
@@ -34,7 +29,7 @@ fn echo_callback(args: List, kwargs: Dict) -> CallResult<(Option<List>, Option<D
 
 fn main() {
     env_logger::init();
-    let connection = Connection::new("ws://127.0.0.1:8090/ws", "wampire_realm");
+    let connection = Connection::new("ws://127.0.0.1:8080/ws", "demo");
     info!("Connecting");
     let mut client = connection.connect().unwrap();
 
@@ -43,28 +38,28 @@ fn main() {
     client
         .register(URI::new("ca.test.add"), Box::new(addition_callback))
         .unwrap()
-        .await()
+        .r#await()
         .unwrap();
 
     info!("Registering Multiplication Procedure");
     let mult_reg = client
         .register(URI::new("ca.test.mult"), Box::new(multiplication_callback))
         .unwrap()
-        .await()
+        .r#await()
         .unwrap();
 
     info!("Unregistering Multiplication Procedure");
-    client.unregister(mult_reg).unwrap().await().unwrap();
+    client.unregister(mult_reg).unwrap().r#await().unwrap();
 
     info!("Registering Echo Procedure");
     client
         .register(URI::new("ca.test.echo"), Box::new(echo_callback))
         .unwrap()
-        .await()
+        .r#await()
         .unwrap();
 
     println!("Press enter to quit");
     let mut input = String::new();
     io::stdin().read_line(&mut input).unwrap();
-    client.shutdown().unwrap().await().unwrap();
+    client.shutdown().unwrap().r#await().unwrap();
 }

--- a/examples/pubsubclient.rs
+++ b/examples/pubsubclient.rs
@@ -1,14 +1,12 @@
-extern crate eventual;
-extern crate wampire;
-use eventual::Async;
 use std::io;
 use std::sync::{Arc, Mutex};
+
+use env_logger;
+use eventual::Async;
+use log::info;
+
 use wampire::client::{Client, Connection, Subscription};
 use wampire::{MatchingPolicy, Value, URI};
-
-#[macro_use]
-extern crate log;
-extern crate env_logger;
 
 enum Command {
     Sub,
@@ -100,7 +98,7 @@ fn subscribe(
             subscriptions.lock().unwrap().push(subscription);
             Ok(())
         })
-        .await()
+        .r#await()
         .unwrap();
 }
 
@@ -131,7 +129,7 @@ fn unsubscribe(
                     println!("Successfully unsubscribed from {}", topic);
                     Ok(())
                 })
-                .await()
+                .r#await()
                 .unwrap();
         }
         Err(_) => {
@@ -162,7 +160,7 @@ fn publish(client: &mut Client, args: &[String]) {
     client
         .publish_and_acknowledge(URI::new(uri), Some(args), None)
         .unwrap()
-        .await()
+        .r#await()
         .unwrap();
 }
 
@@ -202,7 +200,7 @@ fn event_loop(mut client: Client) {
             Command::Invalid(bad_command) => print!("Invalid command: {}", bad_command),
         }
     }
-    client.shutdown().unwrap().await().unwrap();
+    client.shutdown().unwrap().r#await().unwrap();
 }
 
 fn main() {

--- a/src/bin/wampire.rs
+++ b/src/bin/wampire.rs
@@ -1,10 +1,7 @@
-extern crate wampire;
+use argparse::{ArgumentParser, Store, StoreTrue};
+use env_logger;
 
 use wampire::router::Router;
-extern crate env_logger;
-
-extern crate argparse;
-use argparse::{ArgumentParser, StoreTrue, Store};
 
 fn main() {
     env_logger::init();
@@ -12,18 +9,16 @@ fn main() {
     let mut verbose = false;
     let mut port = "8090".to_string();
     let mut realm = "wampire_realm".to_string();
-    {  // this block limits scope of borrows by ap.refer() method
+    {
+        // this block limits scope of borrows by ap.refer() method
         let mut ap = ArgumentParser::new();
         ap.set_description("Options");
         ap.refer(&mut verbose)
-            .add_option(&["-v", "--verbose"], StoreTrue,
-                        "Be verbose");
+            .add_option(&["-v", "--verbose"], StoreTrue, "Be verbose");
         ap.refer(&mut port)
-            .add_option(&["-P", "--port"], Store,
-                        "Listening port");
+            .add_option(&["-P", "--port"], Store, "Listening port");
         ap.refer(&mut realm)
-            .add_option(&["-R", "--realm"], Store,
-                        "Handling realm");
+            .add_option(&["-R", "--realm"], Store, "Handling realm");
         ap.parse_args_or_exit();
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,21 @@
-use super::{ErrorType, Message, ID};
-use messages::{self, Reason};
-use rmp_serde::decode::Error as MsgPackError;
-use serde_json::Error as JSONError;
 use std::fmt;
 use std::sync::mpsc::SendError;
+
+use rmp_serde::decode::Error as MsgPackError;
+use serde_json::Error as JSONError;
 use url::ParseError;
 use ws::Error as WSError;
+
+use crate::messages::{self, Reason};
+
+use super::{ErrorType, Message, ID};
 
 #[derive(Debug)]
 pub struct Error {
     pub kind: ErrorKind,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ErrorKind {
     WSError(WSError),
@@ -31,7 +35,7 @@ pub enum ErrorKind {
 }
 impl Error {
     pub fn new(kind: ErrorKind) -> Error {
-        Error { kind: kind }
+        Error { kind }
     }
 
     fn get_description(&self) -> String {
@@ -45,7 +49,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.get_description())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,17 @@
-#![cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-extern crate serde;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-extern crate eventual;
-extern crate itertools;
-extern crate rand;
-extern crate rmp;
-extern crate rmp_serde;
-extern crate url;
-extern crate ws;
-
-#[macro_use]
-extern crate log;
-
 pub mod client;
 mod error;
 mod messages;
 pub mod router;
 mod utils;
 
-use self::error::*;
+use self::error::{Error, ErrorKind};
 
-pub use client::{Client, Connection};
-pub use messages::{ArgDict, ArgList, CallError, Dict, InvocationPolicy, List, MatchingPolicy,
-                   Reason, Value, URI};
-use messages::{ErrorType, Message};
-pub use router::Router;
+pub use crate::client::{Client, Connection};
+pub use crate::messages::{
+    ArgDict, ArgList, CallError, Dict, InvocationPolicy, List, MatchingPolicy, Reason, Value, URI,
+};
+use crate::messages::{ErrorType, Message};
+pub use crate::router::Router;
 
 pub type CallResult<T> = Result<T, CallError>;
 pub type WampResult<T> = Result<T, Error>;

--- a/src/messages/types/error.rs
+++ b/src/messages/types/error.rs
@@ -1,7 +1,10 @@
-use super::{Dict, List};
-use serde;
 use std::fmt;
-use URI;
+
+use serde;
+
+use crate::URI;
+
+use super::{Dict, List};
 
 #[derive(Hash, Eq, PartialEq, Debug)]
 pub enum Reason {
@@ -49,9 +52,9 @@ impl CallError {
     #[inline]
     pub fn new(reason: Reason, args: Option<List>, kwargs: Option<Dict>) -> CallError {
         CallError {
-            reason: reason,
-            args: args,
-            kwargs: kwargs,
+            reason,
+            args,
+            kwargs,
         }
     }
 
@@ -107,7 +110,7 @@ impl Reason {
 }
 
 impl fmt::Display for Reason {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.get_string())
     }
 }
@@ -137,7 +140,7 @@ impl<'de> serde::Deserialize<'de> for Reason {
 impl<'de> serde::de::Visitor<'de> for ReasonVisitor {
     type Value = Reason;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("error reason uri")
     }
 
@@ -205,7 +208,7 @@ impl<'de> serde::Deserialize<'de> for ErrorType {
 impl<'de> serde::de::Visitor<'de> for ErrorTypeVisitor {
     type Value = ErrorType;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("Integer representing an error type")
     }
 

--- a/src/messages/types/mod.rs
+++ b/src/messages/types/mod.rs
@@ -1,16 +1,17 @@
+use std::fmt;
+
+use serde;
+
 mod error;
 mod options;
 mod roles;
 mod value;
+pub use error::*;
+pub use options::*;
+pub use roles::*;
+pub use value::*;
 
-use serde;
-use std::fmt;
-
-pub use messages::types::error::*;
-pub use messages::types::options::*;
-pub use messages::types::roles::*;
-pub use messages::types::value::*;
-
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_not(b: &bool) -> bool {
     !*b
 }
@@ -53,16 +54,18 @@ struct MatchingPolicyVisitor;
 struct InvocationPolicyVisitor;
 
 impl MatchingPolicy {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     fn is_strict(&self) -> bool {
-        self == &MatchingPolicy::Strict
+        *self == MatchingPolicy::Strict
     }
 }
 
 impl InvocationPolicy {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     fn is_single(&self) -> bool {
-        self == &InvocationPolicy::Single
+        *self == InvocationPolicy::Single
     }
 }
 
@@ -110,7 +113,7 @@ impl<'de> serde::Deserialize<'de> for MatchingPolicy {
 impl<'de> serde::de::Visitor<'de> for MatchingPolicyVisitor {
     type Value = MatchingPolicy;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("matching policy for registration")
     }
 
@@ -158,7 +161,7 @@ impl<'de> serde::Deserialize<'de> for InvocationPolicy {
 impl<'de> serde::de::Visitor<'de> for InvocationPolicyVisitor {
     type Value = InvocationPolicy;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("invocation policy for a procedure")
     }
 

--- a/src/messages/types/options.rs
+++ b/src/messages/types/options.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use super::{is_not, ClientRoles, InvocationPolicy, MatchingPolicy, RouterRoles, URI};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
@@ -22,7 +24,11 @@ pub struct ErrorDetails {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct SubscribeOptions {
-    #[serde(default, rename = "match", skip_serializing_if = "MatchingPolicy::is_strict")]
+    #[serde(
+        default,
+        rename = "match",
+        skip_serializing_if = "MatchingPolicy::is_strict"
+    )]
     pub pattern_match: MatchingPolicy,
 }
 
@@ -34,10 +40,18 @@ pub struct PublishOptions {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct RegisterOptions {
-    #[serde(default, rename = "match", skip_serializing_if = "MatchingPolicy::is_strict")]
+    #[serde(
+        default,
+        rename = "match",
+        skip_serializing_if = "MatchingPolicy::is_strict"
+    )]
     pub pattern_match: MatchingPolicy,
 
-    #[serde(default, rename = "invoke", skip_serializing_if = "InvocationPolicy::is_single")]
+    #[serde(
+        default,
+        rename = "invoke",
+        skip_serializing_if = "InvocationPolicy::is_single"
+    )]
     pub invocation_policy: InvocationPolicy,
 }
 
@@ -70,15 +84,12 @@ pub struct ResultDetails {}
 
 impl HelloDetails {
     pub fn new(roles: ClientRoles) -> HelloDetails {
-        HelloDetails {
-            roles: roles,
-            agent: None,
-        }
+        HelloDetails { roles, agent: None }
     }
 
     pub fn new_with_agent(roles: ClientRoles, agent: &str) -> HelloDetails {
         HelloDetails {
-            roles: roles,
+            roles,
             agent: Some(agent.to_string()),
         }
     }
@@ -86,15 +97,12 @@ impl HelloDetails {
 
 impl WelcomeDetails {
     pub fn new(roles: RouterRoles) -> WelcomeDetails {
-        WelcomeDetails {
-            roles: roles,
-            agent: None,
-        }
+        WelcomeDetails { roles, agent: None }
     }
 
     pub fn new_with_agent(roles: RouterRoles, agent: &str) -> WelcomeDetails {
         WelcomeDetails {
-            roles: roles,
+            roles,
             agent: Some(agent.to_string()),
         }
     }
@@ -122,9 +130,7 @@ impl SubscribeOptions {
 
 impl PublishOptions {
     pub fn new(acknowledge: bool) -> PublishOptions {
-        PublishOptions {
-            acknowledge: acknowledge,
-        }
+        PublishOptions { acknowledge }
     }
 
     pub fn should_acknowledge(&self) -> bool {

--- a/src/messages/types/roles.rs
+++ b/src/messages/types/roles.rs
@@ -1,5 +1,8 @@
-use super::is_not;
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::is_not;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ClientRoles {

--- a/src/messages/types/value.rs
+++ b/src/messages/types/value.rs
@@ -1,9 +1,12 @@
-use super::{CallError, Reason};
-use itertools::Itertools;
-use serde;
 use std::collections::HashMap;
 use std::fmt;
-use CallResult;
+
+use itertools::Itertools;
+use serde;
+
+use crate::CallResult;
+
+use super::{CallError, Reason};
 
 pub type Dict = HashMap<String, Value>;
 pub type List = Vec<Value>;
@@ -158,10 +161,12 @@ impl Value {
             Value::Dict(ref d) => {
                 let mut result = String::new();
                 result.push('{');
-                result.push_str(&d.iter()
-                    .take(50)
-                    .map(|(key, value)| format!("{}:{}", key, value.summarize()))
-                    .join(","));
+                result.push_str(
+                    &d.iter()
+                        .take(50)
+                        .map(|(key, value)| format!("{}:{}", key, value.summarize()))
+                        .join(","),
+                );
                 result.push('}');
                 result
             }
@@ -178,10 +183,12 @@ impl Value {
             Value::List(ref l) => {
                 let mut result = String::new();
                 result.push('[');
-                result.push_str(&l.iter()
-                    .take(50)
-                    .map(|element| element.summarize())
-                    .join(","));
+                result.push_str(
+                    &l.iter()
+                        .take(50)
+                        .map(|element| element.summarize())
+                        .join(","),
+                );
                 result.push(']');
                 result
             }
@@ -194,7 +201,7 @@ impl Value {
 impl<'de> serde::de::Visitor<'de> for ValueVisitor {
     type Value = Value;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("JSON value")
     }
 
@@ -326,7 +333,7 @@ impl<'de> serde::Deserialize<'de> for URI {
 impl<'de> serde::de::Visitor<'de> for URIVisitor {
     type Value = URI;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("URI")
     }
     #[inline]

--- a/src/router/rpc/mod.rs
+++ b/src/router/rpc/mod.rs
@@ -1,15 +1,18 @@
-mod patterns;
-
 use std::sync::Arc;
 
-pub use router::rpc::patterns::RegistrationPatternNode;
+use log::{debug, info};
 
+use crate::messages::{
+    CallOptions, ErrorType, InvocationDetails, Message, Reason, RegisterOptions, ResultDetails,
+    YieldOptions, URI,
+};
+use crate::{Dict, Error, ErrorKind, List, MatchingPolicy, WampResult, ID};
+
+use super::messaging::send_message;
 use super::{random_id, ConnectionHandler};
 
-use messages::{CallOptions, ErrorType, InvocationDetails, Message, Reason, RegisterOptions,
-               ResultDetails, YieldOptions, URI};
-use router::messaging::send_message;
-use {Dict, Error, ErrorKind, List, MatchingPolicy, WampResult, ID};
+mod patterns;
+pub use self::patterns::RegistrationPatternNode;
 
 impl ConnectionHandler {
     pub fn handle_register(
@@ -140,7 +143,7 @@ impl ConnectionHandler {
                 };
                 let invocation_message =
                     Message::Invocation(invocation_id, procedure_id, details, args, kwargs);
-                try!(send_message(registrant, &invocation_message));
+                send_message(registrant, &invocation_message)?;
 
                 Ok(())
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
+use std::io::Write;
+
 use rmp::encode::{write_map_len, write_str, ValueWriteError};
 use rmp::Marker;
 use rmp_serde::encode::VariantWriter;
-use std::io::Write;
 
 pub struct StructMapWriter;
 


### PR DESCRIPTION
It is just the first step.

I want to migrate wampire to Rust 1.39 async/await. To do that, I am going to replace `eventual` with `tokio` (0.2 alpha)  and `ws` with [`tungstenite`](https://github.com/snapview/tungstenite-rs) & [`tokio-tungstenite`](https://github.com/snapview/tokio-tungstenite) ([async/await support is currently in PR](https://github.com/snapview/tokio-tungstenite/pull/68)).